### PR TITLE
Uses payload template value

### DIFF
--- a/mbc-transactional-email.php
+++ b/mbc-transactional-email.php
@@ -83,7 +83,7 @@ class MBC_TransactionalEmail
         )
       ),
       'tags' => array(
-        $payload['activity']
+        $payload['email_tags']
       )
     );
 


### PR DESCRIPTION
Fixes #11

Adjusts to use template and tag values in message payload as defined by site specific custom Drupal module using `message_broker_producer_request()`.

Related:
Mandrill `send-template` API:  https://mandrillapp.com/api/docs/messages.JSON.html#method=send-template
https://github.com/DoSomething/dosomething/pull/3387
