### PR TITLE
Issue33 campaign language

### DIFF
--- a/mbc-transactional-email.config.inc
+++ b/mbc-transactional-email.config.inc
@@ -35,12 +35,10 @@ $mbConfig->setProperty('generalSettings', [
     'name' => $generalSettings->email->name,
   ]
 ]);
-
 $mbConfig->setProperty('statHat', new StatHat([
   'ez_key' => getenv("STATHAT_EZKEY"),
   'debug' => getenv("DISABLE_STAT_TRACKING")
 ]));
-
 $mbConfig->setProperty('rabbit_credentials', [
   'host' =>  getenv("RABBITMQ_HOST"),
   'port' => getenv("RABBITMQ_PORT"),
@@ -56,12 +54,9 @@ $mbConfig->setProperty('rabbitapi_credentials', [
 ]);
 
 // Create connection to exchange and queue for processing of queue contents.
-$mbRabbitConfig = $mbConfig->constructRabbitConfig('transactionalExchange', array('transactionalQueue'));
-$mbConfig->setProperty('messageBroker_config', $mbRabbitConfig);
-
 $rabbitCredentials = $mbConfig->getProperty('rabbit_credentials');
-$messageBrokerConfig = $mbConfig->getProperty('messageBroker_config');
-$mbConfig->setProperty('messageBroker', new MessageBroker($rabbitCredentials, $messageBrokerConfig));
+$mbRabbitConfig = $mbConfig->constructRabbitConfig('transactionalExchange', array('transactionalQueue'));
+$mbConfig->setProperty('messageBroker', new MessageBroker($rabbitCredentials, $mbRabbitConfig));
 
 $mbConfig->setProperty('mbRabbitMQManagementAPI', new MB_RabbitMQManagementAPI([
   'domain' => getenv("MB_RABBITMQ_MANAGEMENT_API_HOST"),

--- a/mbc-transactional-email.config.inc
+++ b/mbc-transactional-email.config.inc
@@ -55,7 +55,7 @@ $mbConfig->setProperty('rabbitapi_credentials', [
 
 // Create connection to exchange and queue for processing of queue contents.
 $rabbitCredentials = $mbConfig->getProperty('rabbit_credentials');
-$mbRabbitConfig = $mbConfig->constructRabbitConfig('transactionalExchange', array('transactionalQueue'));
+$mbRabbitConfig = $mbConfig->constructRabbitConfig('transactionalExchange', ['transactionalQueue']);
 $mbConfig->setProperty('messageBroker', new MessageBroker($rabbitCredentials, $mbRabbitConfig));
 
 $mbConfig->setProperty('mbRabbitMQManagementAPI', new MB_RabbitMQManagementAPI([

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -113,12 +113,12 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
     
     if (empty($this->message['email'])) {
       echo '- canProcess(), email not set.', PHP_EOL;
-      return FALSE;
+      return false;
     }
 
    if (filter_var($this->message['email'], FILTER_VALIDATE_EMAIL) === false) {
       echo '- canProcess(), failed FILTER_VALIDATE_EMAIL: ' . $this->message['email'], PHP_EOL;
-      return FALSE;
+      return false;
     }
     else {
       $this->message['email'] = filter_var($this->message['email'], FILTER_VALIDATE_EMAIL);
@@ -126,10 +126,10 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
     if (empty($this->message['email_template']) && empty($this->message['email-template'])) {
       throw new Exception('Template not defined.');
-      return FALSE;
+      return false;
     }
 
-    return TRUE;
+    return true;
   }
 
   /**
@@ -214,7 +214,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
     $statName = 'mbc-transactional-email: Mandrill ';
     if (isset($mandrillResults[0]['reject_reason']) && $mandrillResults[0]['reject_reason'] != NULL) {
-      throw new Exception(print_r($mandrillResults[0], TRUE));
+      throw new Exception(print_r($mandrillResults[0], true));
       $statName .= 'Error: ' . $mandrillResults[0]['reject_reason'];
     }
     elseif (isset($mandrillResults[0]['status']) && $mandrillResults[0]['status'] != 'error') {
@@ -293,11 +293,11 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
         break;
 
        default:
-         $templateName = FALSE;
+         $templateName = false;
 
     }
 
-    if ($templateName == FALSE) {
+    if ($templateName == false) {
       $statName = 'mbc-transactional-email: Invalid Template';
       $this->statHat->ezCount($statName, 1);
     }

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -302,7 +302,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
     endswitch;
 
-    if ($templateName == false) {
+    if (!$templateName) {
       $statName = 'mbc-transactional-email: Invalid Template';
       $this->statHat->ezCount($statName, 1);
     }
@@ -325,21 +325,20 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
    */
   protected function logConsumption($targetName = NULL) {
 
-    if ($targetName != NULL) {
-      echo '** Consuming ' . $targetName . ': ' . $this->message[$targetName], PHP_EOL;
-      if (isset($this->message['activity'])) {
-         echo '- activity: ' . $this->message['activity'], PHP_EOL;
-      }
-      if (isset($this->message['user_country'])) {
-         echo '- User country: ' . $this->message['user_country'], PHP_EOL;
-      }
-      if (isset($this->message['campaign_language'])) {
-         echo '- Campaign language: ' . $this->message['campaign_language'], PHP_EOL;
-      }
-      echo PHP_EOL;
-    } else {
+    if (is_null($targetName)) {
       echo $targetName . ' is not defined.', PHP_EOL;
     }
-  }
 
+    echo '** Consuming ' . $targetName . ': ' . $this->message[$targetName], PHP_EOL;
+    if (isset($this->message['activity'])) {
+       echo '- activity: ' . $this->message['activity'], PHP_EOL;
+    }
+    if (isset($this->message['user_country'])) {
+       echo '- User country: ' . $this->message['user_country'], PHP_EOL;
+    }
+    if (isset($this->message['campaign_language'])) {
+       echo '- Campaign language: ' . $this->message['campaign_language'], PHP_EOL;
+    }
+    echo PHP_EOL;
+  }
 }

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -189,6 +189,9 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       );
     }
 
+    // Needed to support email-template rather than email_template.
+    // Product of a legacy bug / non-standard var name in various other producer apps that
+    // send messages to this consumer.
     if (isset($message['email-template'])) {
       $message['email_template'] = $message['email-template'];
     }

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -111,7 +111,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
    */
   protected function canProcess() {
     
-    if (!(isset($this->message['email']))) {
+    if (empty($this->message['email'])) {
       echo '- canProcess(), email not set.', PHP_EOL;
       return FALSE;
     }
@@ -124,7 +124,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       $this->message['email'] = filter_var($this->message['email'], FILTER_VALIDATE_EMAIL);
     }
 
-    if (!(isset($this->message['email_template'])) && !(isset($this->message['email-template']))) {
+    if (empty($this->message['email_template']) && empty($this->message['email-template'])) {
       throw new Exception('Template not defined.');
       return FALSE;
     }

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -235,6 +235,10 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
    *   Settings of the message from the consumed queue.
    */
   protected function setTemplateName($message) {
+   
+    $activity = str_replace('_', '-', $message['activity']);
+    $userCountry = strtoupper($message['user_country']);
+    $campaignLanguage = strtolower($message['campaign_language']);
 
     switch ($message['activity']) {
 
@@ -242,41 +246,41 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       case "user_password":
 
         // mb-campaign-signup-KR
-        if ($message['user_country'] == 'US') {
+        if ($message['user_country'] === 'US') {
           $templateName = $message['email_template'];
         }
         elseif ($this->mbToolbox->isDSAffiliate($countryCode)) {
           $templateName = $message['email_template'];
         }
         else {
-          $templateName = 'mb-' . str_replace('_', '-', $message['activity']) . '-GL';
+          $templateName = 'mb-' . $activity . '-GL';
         }
         break;
 
       case "campaign_signup":
       case "campaign_reportback":
 
-        switch (strtolower($message['campaign_language'])) {
+        switch ($campaignLanguage) {
 
           case 'en':
-            if (strtoupper($message['user_country']) == 'US') {
-              $templateName = 'mb-' . str_replace('_', '-', $message['activity']) . '-US';
+            if ($userCountry === 'US') {
+              $templateName = 'mb-' . $activity . '-US';
             }
             else {
-              $templateName = 'mb-' . str_replace('_', '-', $message['activity']) . '-XG';
+              $templateName = 'mb-' . $activity . '-XG';
             }
             break;
 
           case 'en-global':
-            $templateName = 'mb-' . str_replace('_', '-', $message['activity']) . '-XG';
+            $templateName = 'mb-' . $activity . '-XG';
             break;
 
           case 'es-mx':
-            $templateName = 'mb-' . str_replace('_', '-', $message['activity']) . '-MX';
+            $templateName = 'mb-' . $activity . '-MX';
             break;
 
           case 'pt-br':
-            $templateName = 'mb-' . str_replace('_', '-', $message['activity']) . '-BR';
+            $templateName = 'mb-' . $activity . '-BR';
             break;
 
         }
@@ -284,7 +288,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
       case "vote":
 
-        if (strtoupper($message['user_country']) == 'US') {
+        if ($userCountry === 'US') {
           $templateName = 'mb-cgg-vote-US';
         }
         else {

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -235,12 +235,12 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
    *   Settings of the message from the consumed queue.
    */
   protected function setTemplateName($message) {
-   
+
     $activity = str_replace('_', '-', $message['activity']);
     $userCountry = strtoupper($message['user_country']);
     $campaignLanguage = strtolower($message['campaign_language']);
 
-    switch ($message['activity']) {
+    switch ($message['activity']):
 
       case "user_register":
       case "user_password":
@@ -260,7 +260,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       case "campaign_signup":
       case "campaign_reportback":
 
-        switch ($campaignLanguage) {
+        switch ($campaignLanguage):
 
           case 'en':
             if ($userCountry === 'US') {
@@ -283,7 +283,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
             $templateName = 'mb-' . $activity . '-BR';
             break;
 
-        }
+        endswitch;
         break;
 
       case "vote":
@@ -298,8 +298,9 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
        default:
          $templateName = false;
+         break;
 
-    }
+    endswitch;
 
     if ($templateName == false) {
       $statName = 'mbc-transactional-email: Invalid Template';

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -124,7 +124,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       $this->message['email'] = filter_var($this->message['email'], FILTER_VALIDATE_EMAIL);
     }
 
-    if (!(isset($this->message['email_template'])) || !(isset($this->message['email-template']))) {
+    if (!(isset($this->message['email_template'])) && !(isset($this->message['email-template']))) {
       throw new Exception('Template not defined.');
       return FALSE;
     }
@@ -256,10 +256,10 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       case "campaign_signup":
       case "campaign_reportback":
 
-        switch ($message['campaign_language']) {
+        switch (strtolower($message['campaign_language'])) {
 
           case 'en':
-            if ($message['user_country'] == 'US') {
+            if (strtoupper($message['user_country']) == 'US') {
               $templateName = 'mb-' . str_replace('_', '-', $message['activity']) . '-US';
             }
             else {
@@ -284,11 +284,11 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
       case "vote":
 
-        if ($message['user_country'] != 'US') {
-          $templateName = 'mb-cgg2015-vote-GL';
+        if (strtoupper($message['user_country']) == 'US') {
+          $templateName = 'mb-cgg-vote-US';
         }
         else {
-          $templateName = 'mb-cgg2015-vote-US';
+          $templateName = 'mb-cgg-vote-XG';
         }
         break;
 


### PR DESCRIPTION
Fixes #33 

- Add support for `campaign_language` for `campaign_signup` and `campaign_reportback` transactionals.
- The template name sent in the requests to Mandrill should support sending transactional email messages in the language of the campaign rather than the current `user_language`.

**Related**:
- https://github.com/DoSomething/phoenix/pull/6029

**To Test**:
- See `transactionalQueue` for 4 test messages to process by `mbc-transactional-email`. Adjust `email` value to desired test address:
```
Array
(
    [activity] => campaign_signup
    [email] => dlee@dosomething.org
    [uid] => 3084197
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 4.8 million
            [FNAME] => Akshat
            [CAMPAIGN_TITLE] => Love Letters 
            [CAMPAIGN_LINK] => https://www.dosomething.org/campaigns/love-letters?source=node/3755
            [CALL_TO_ACTION] => Make Valentine’s Day cards to show an older adult you care.
            [STEP_ONE] => Make Your Cards!
            [STEP_TWO] => Snap a Pic
            [STEP_THREE] => Mail Your Cards!
        )

    [user_country] => US
    [user_language] => en
    [campaign_language] => en
    [email_template] => mb-campaign-signup-US
    [subscribed] => 1
    [event_id] => 3755
    [campaign_country] => us
    [email_tags] => Array
        (
            [0] => 3755
            [1] => drupal_campaign_signup
        )

    [mailchimp_list_id] => f2fab1dfd4
    [mailchimp_grouping_id] => 10637
    [mailchimp_group_name] => LoveLetters2014
    [mobile] => 9086722886
    [mc_opt_in_path_id] => 197729
    [activity_timestamp] => 1452637974
    [application_id] => US
)
```
Payload in PHP seralized format:
```
a:19:{s:8:"activity";s:15:"campaign_signup";s:5:"email";s:20:"dlee@dosomething.org";s:3:"uid";s:7:"3084197";s:10:"merge_vars";a:8:{s:12:"MEMBER_COUNT";s:11:"4.8 million";s:5:"FNAME";s:6:"Akshat";s:14:"CAMPAIGN_TITLE";s:13:"Love Letters ";s:13:"CAMPAIGN_LINK";s:67:"https://www.dosomething.org/campaigns/love-letters?source=node/3755";s:14:"CALL_TO_ACTION";s:61:"Make Valentine’s Day cards to show an older adult you care.";s:8:"STEP_ONE";s:16:"Make Your Cards!";s:8:"STEP_TWO";s:10:"Snap a Pic";s:10:"STEP_THREE";s:16:"Mail Your Cards!";}s:12:"user_country";s:2:"US";s:13:"user_language";s:2:"en";s:17:"campaign_language";s:2:"en";s:14:"email_template";s:21:"mb-campaign-signup-US";s:10:"subscribed";i:1;s:8:"event_id";s:4:"3755";s:16:"campaign_country";s:2:"us";s:10:"email_tags";a:2:{i:0;s:4:"3755";i:1;s:22:"drupal_campaign_signup";}s:17:"mailchimp_list_id";s:10:"f2fab1dfd4";s:21:"mailchimp_grouping_id";s:5:"10637";s:20:"mailchimp_group_name";s:15:"LoveLetters2014";s:6:"mobile";s:10:"9086722886";s:17:"mc_opt_in_path_id";s:6:"197729";s:18:"activity_timestamp";i:1452637974;s:14:"application_id";s:2:"US";}
```
Test processing messages in `Sandbox` RabbitMQ vhost. Adjust `campaign_country` and `campaign_language` values to test receipt of transactional email messages in the expected languages.