### PR TITLE
Forward consumed message to dead letters on an exception.

### DIFF
--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -102,16 +102,8 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
     }
     catch(Exception $e) {
-
-      if (strpos($e->getMessage(), 'Template not defined') !== false) {
-        echo '**ALERT: ' . $e->getMessage(), PHP_EOL;
-        $this->messageBroker->sendAck($this->message['payload']);
-      }
-      else {
-        echo 'Error sending transactional email to: ' . $this->message['email'] . '. Error: ' . $e->getMessage() . PHP_EOL;
-        $errorDetails = $e->getMessage();
-        $this->messageBroker->sendAck($this->message['payload']);
-      }
+      echo '**ALERT: ' . $e->getMessage(), PHP_EOL;
+      $this->messageBroker->sendAck($this->message['payload']);
       parent::deadLetter($this->message, 'MBC_TransactionalEmail_Consumer->consumeTransactionalQueue() Error', $e->getMessage());
     }
 

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -105,7 +105,6 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
       if (strpos($e->getMessage(), 'Template not defined') !== false) {
         echo '**ALERT: ' . $e->getMessage(), PHP_EOL;
-        parent::deadLetter($this->message, 'MBC_TransactionalEmail_Consumer->consumeTransactionalQueue() Error', $e->getMessage());
         $this->messageBroker->sendAck($this->message['payload']);
       }
       else {
@@ -113,6 +112,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
         $errorDetails = $e->getMessage();
         $this->messageBroker->sendAck($this->message['payload']);
       }
+      parent::deadLetter($this->message, 'MBC_TransactionalEmail_Consumer->consumeTransactionalQueue() Error', $e->getMessage());
     }
 
     // @todo: Throttle the number of consumers running. Based on the number of messages


### PR DESCRIPTION
Fixes an issue when messages consumed which encountered unknown exception are deleted rather then forwarded to the Dead Letters queue.
Closes #37.