### PR TITLE
Delegate default campaign sign up processing to mbc-transactional-digest

### DIFF
--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -136,6 +136,11 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       return false;
     }
 
+    if (!empty($this->message['activity']) && $this->message['activity'] === 'campaign_signup') {
+      echo '- canProcess(), processing campaign signups is deprecated in favor of mbc-transactional-digest.', PHP_EOL;
+      return false;
+    }
+
    if (filter_var($this->message['email'], FILTER_VALIDATE_EMAIL) === false) {
       echo '- canProcess(), failed FILTER_VALIDATE_EMAIL: ' . $this->message['email'], PHP_EOL;
       return false;
@@ -273,6 +278,13 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
    *   Settings of the message from the consumed queue.
    */
   protected function setTemplateName($message) {
+    // `campaign_signup_single` is the fallback to normal email when user activity
+    // isn't qualified for the transactional digest.
+    // However, `campaign_signup_single` should be processed exactly like
+    // the old transactional signup, including template naming.
+    if ($message['activity'] === 'campaign_signup_single') {
+      $message['activity'] = 'campaign_signup';
+    }
 
     $activity = str_replace('_', '-', $message['activity']);
     $userCountry = '';


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ This changes may be destructive for normal messaging ⚠️ ⚠️ ⚠️

#### What's this PR do?
Makes the consumer to skip messages with `campaign_signup` activity and accept `campaign_signup_single` instead and process them as normal  `campaign_signup` messages.

#### Any background context you want to provide?
1. `campaign_signup` messages are skipped because they are processed by `mbc-transactional-digest` now
2. When `mbc-transactional-digest` doesn't qualify user activity as digest-worthy, it generates new message `campaign_signup_single`, that is processed as normal `campaign_signup` in mbc-transactional-digest`

#### What are the relevant tickets?
Ref DoSomething/Quicksilver-PHP#62

