### PR TITLE
Patch 41

### DIFF
--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -244,21 +244,21 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
     if (isset($mandrillResults[0]['reject_reason']) && $mandrillResults[0]['reject_reason'] != NULL) {
       $statName .= 'Error: ' . $mandrillResults[0]['reject_reason'];
       if (strpos($mandrillResults[0]['reject_reason'], '500 Internal Server Error') || strpos($mandrillResults[0]['reject_reason'], '502 Bad Gateway')) {
-          sleep(30);
-          $this->messageBroker->sendNack($this->message['payload']);
-        }
-        else {
+        sleep(30);
+        $this->messageBroker->sendNack($this->message['payload']);
+      }
+      else {
 
-          $errorDetails = [
-            'email' => $mandrillResults[0]['email'],
-            'error' => $mandrillResults[0]['reject_reason'],
-            'code' => '000'
-          ];
-          $payload = serialize($errorDetails);
-          $this->messageBroker->publish($payload, 'user.mailchimp.error');
+        $errorDetails = [
+          'email' => $mandrillResults[0]['email'],
+          'error' => $mandrillResults[0]['reject_reason'],
+          'code' => '000'
+        ];
+        $payload = serialize($errorDetails);
+        $this->messageBroker->publish($payload, 'user.mailchimp.error');
 
-          throw new Exception(print_r($mandrillResults[0], true));
-        }
+        throw new Exception(print_r($mandrillResults[0], true));
+      }
     }
     elseif (isset($mandrillResults[0]['status']) && $mandrillResults[0]['status'] != 'error') {
       echo '-> mbc-transactional-email Mandrill message sent: ' . $this->request['to'][0]['email'] . ' - ' . date('D M j G:i:s T Y'), PHP_EOL;

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -113,7 +113,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
 
     echo '-------  mbc-transactional-email - MBC_TransactionalEmail_Consumer->consumeTransactionalQueue() - ' . date('j D M Y G:i:s T') . ' END -------', PHP_EOL . PHP_EOL;
   }
-  
+
   /**
    * Conditions to test before processing the message.
    *
@@ -125,7 +125,7 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       echo '- canProcess(), transactionals disabled.', PHP_EOL;
       return false;
     }
-    
+
     if (empty($this->message['email'])) {
       echo '- canProcess(), email not set.', PHP_EOL;
       return false;


### PR DESCRIPTION
#### What's this PR do?
- Sets up transactional email consumer to skip messages rejected on Mandrill as [soft or hard bounces](http://kb.mailchimp.com/delivery/deliverability-research/soft-vs-hard-bounces) so they don't end up piling up in the [`deadLetterQueue`](https://rabbit.dosomething.org/#/queues/dosomething/deadLetterQueue).

#### Any background context you want to provide?
There's a script that monitors `deadLetterQueue` and posts an alter to Slack when there are more than 50 messages. It's getting really noisy after that.

Logging soft and hard bounces is meaningless because emails essentially are undeliverable or don't exists.

#### What are the relevant tickets?
Fixes #41.
Trello: https://trello.com/c/aWQ2ko4i/77-quicksilver-as-a-ds-developer-i-want-to-make-improvements-to-deadletter-queue-so-that-it-does-not-send-push-notifications-for-ha
