### PR TITLE
Only override templates for US users.

### DIFF
--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -400,7 +400,9 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
         endswitch;
 
         // Override template from exceptions array.
-        if (!empty($message['event_id']) && !empty($this->campaignSignupOverrideSuffix[$message['event_id']])) {
+        if ($userCountry === 'US'
+          && !empty($message['event_id'])
+          && !empty($this->campaignSignupOverrideSuffix[$message['event_id']])) {
           $templateName .= '-' . $this->campaignSignupOverrideSuffix[$message['event_id']];
         }
         break;


### PR DESCRIPTION
#### What's this PR do?
- Changes template override rule to exclude non-US users

#### How should this be manually tested?
Tested locally

#### What are the relevant tickets?
Ref #46 
Trello https://trello.com/c/2cJNgGEk/257-5-email-supress-replace-email-templates-suspended-for-what
