### PR TITLE
Exclude all fake import addresses

### DIFF
--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -148,8 +148,8 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
       return false;
     }
 
-    if (preg_match('/@mobile\.import$/', $this->message['email'])) {
-      echo '- canProcess(), Mobile placeholder address: ' . $this->message['email'], PHP_EOL;
+    if (preg_match('/@.*\.import$/', $this->message['email'])) {
+      echo '- canProcess(), import placeholder address: ' . $this->message['email'], PHP_EOL;
       return false;
     }
 


### PR DESCRIPTION
#### What's this PR do?
- Excludes all possible combinations of fake import email addresses from being processed

#### Any background context you want to provide?
Drupal requires an email on every account, but Northstar does not. In order to create Phoenix profile for SMS-only users, we generate fake email address `id@@dosomething.import`, see https://github.com/DoSomething/northstar/pull/507/files#diff-eb9950cc3e4522e41dd68c31824f0497R125. This PR is to handle this exception and exclude this addresses from normal transactional email processing.

cc @mshmsh5000 