### PR TITLE
Override campaign templates for "Sincerely, Us"

### DIFF
--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -76,6 +76,9 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
     // Suspended for WHAT?: ADVOCATE
     // https://www.dosomething.org/us/campaigns/suspended-what-advocate
     7662 => 'advocate',
+    // Sincerely, Us
+    // https://www.dosomething.org/us/campaigns/sincerely-us
+    7656 => 'sincerely-us',
   ];
 
   /**


### PR DESCRIPTION
#### What's this PR do?
Overrides normal signup and reportback templates for "Sincerely, Us", nid 7656, with:

```
mb-campaign-signup-us-sincerely-us
mb-campaign-reportback-us-sincerely-us
```

#### What are the relevant tickets?
Pivotal: https://www.pivotaltracker.com/story/show/143442359
First part: https://github.com/DoSomething/Quicksilver-PHP/pull/112



