### PR TITLE
Override templates for Unlock the Truth and Mirror Messages

### DIFF
--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -79,6 +79,13 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
     // Sincerely, Us
     // https://www.dosomething.org/us/campaigns/sincerely-us
     7656 => 'sincerely-us',
+    // Unlock the Truth
+    // https://www.dosomething.org/us/campaigns/uncover-truth
+    7771 => 'uncover-the-truth',
+    // Mirror Messages
+    // https://www.dosomething.org/us/campaigns/mirror-messages
+    7 => 'mirror-messages',
+
   ];
 
   /**


### PR DESCRIPTION
#### What's this PR do?
Overrides normal signup and reportback templates for:

```
Unlock the Truth
node ID 7771 
mb-campaign-signup-us-uncover-the-truth
mb-campaign-reportback-us-uncover-the-truth

Mirror Messages
node ID 7
mb-campaign-signup-us-mirror-messages
mb-campaign-reportback-us-mirror-messages
```

#### What are the relevant tickets?
Pivotal: https://www.pivotaltracker.com/story/show/144491217
First part: https://github.com/DoSomething/Quicksilver-PHP/pull/114



