### PR TITLE
Remove unsued userMailchimpStatusQueue

### DIFF
--- a/mbc-transactional-email.config.inc
+++ b/mbc-transactional-email.config.inc
@@ -57,8 +57,6 @@ $mbConfig->setProperty('rabbitapi_credentials', [
 $rabbitCredentials = $mbConfig->getProperty('rabbit_credentials');
 $mbRabbitConfig = $mbConfig->constructRabbitConfig('transactionalExchange', ['transactionalQueue']);
 $mbConfig->setProperty('messageBroker', new MessageBroker($rabbitCredentials, $mbRabbitConfig));
-$mbRabbitConfig_Subscribes = $mbConfig->constructRabbitConfig('transactionalExchange', ['userMailchimpStatusQueue']);
-$mbConfig->setProperty('messageBroker_Subscribes', new MessageBroker($rabbitCredentials, $mbRabbitConfig_Subscribes));
 
 $mbRabbitConfig = $mbConfig->constructRabbitConfig('directDeadLetterExchange', ['deadLetterQueue']);
 $mbConfig->setProperty('messageBroker_deadLetter', new MessageBroker($rabbitCredentials, $mbRabbitConfig));

--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -41,14 +41,6 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
   protected $mandrill;
 
   /**
-   * Message Broker connection to send messages to disable/ban user
-   * documents via mb-user-api.
-   *
-   * @var object $messageBroker_Subscribes
-   */
-  protected $messageBroker_Subscribes;
-
-  /**
    * Compiled values for generation of message request to email service
    *
    * @var array $request
@@ -96,7 +88,6 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
    parent::__construct();
    $this->mbToolbox = $this->mbConfig->getProperty('mbToolbox');
    $this->mandrill = $this->mbConfig->getProperty('mandrill');
-   $this->messageBroker_Subscribes = $this->mbConfig->getProperty('messageBroker_Subscribes');
   }
 
   /**


### PR DESCRIPTION
Remove link to `userMailchimpStatusQueue`, it's not used anyways in this consumer.
The queue will be removed soon.