### PR TITLE
Override templates for July 2017 campaigns

### DIFF
--- a/src/MBC_TransactionalEmail_Consumer.php
+++ b/src/MBC_TransactionalEmail_Consumer.php
@@ -77,7 +77,15 @@ class MBC_TransactionalEmail_Consumer extends MB_Toolbox_BaseConsumer
     // Mirror Messages
     // https://www.dosomething.org/us/campaigns/mirror-messages
     7 => 'mirror-messages',
-
+    // All in We Win
+    // https://www.dosomething.org/us/campaigns/all-we-win
+    7831 => 'all-in-we-win',
+    // Treat Yo Friends
+    // https://www.dosomething.org/us/campaigns/treat-yo-friends
+    5646 => 'treat-yo-friends',
+    // Steps for Soldiers
+    // https://www.dosomething.org/us/campaigns/steps-soldiers
+    7822 => 'steps-for-soldiers',
   ];
 
   /**


### PR DESCRIPTION
#### What's this PR do?
Overrides normal signup and reportback templates for:

```
All in We Win
node ID 7831
mb-campaign-signup-us-all-in-we-win
mb-campaign-reportback-us-all-in-we-win

Treat Yo Friends
node ID 5646
mb-campaign-signup-us-treat-yo-friends
mb-campaign-reportback-us-treat-yo-friends

Steps for Soldiers
node ID 7822
mb-campaign-signup-us-steps-for-soldiers
mb-campaign-reportback-us-steps-for-soldiers
```

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/147458033
https://github.com/DoSomething/Quicksilver-PHP/pull/120

